### PR TITLE
feat: 이사 견적 요청 API 구현 및 주소 유틸 수정

### DIFF
--- a/src/app/(protected)/customer/estimate-request/DesktopEstimateForm.tsx
+++ b/src/app/(protected)/customer/estimate-request/DesktopEstimateForm.tsx
@@ -5,7 +5,7 @@ import CalenderDropdown from "./_components/dropdown/CalenderDropdown";
 import MoveTypeCard from "./_components/card/MoveTypeCard";
 import AddressCardModal from "./_components/modal/AddressCardModal";
 import Button from "@/components/Button";
-import { AddressSummary } from "@/utills/AddressSummary";
+import { AddressSummary } from "@/utills/AddressMapper";
 import { Address } from "@/types/Address";
 
 const moveTypes = [
@@ -121,7 +121,7 @@ export default function DesktopEstimateForm() {
             setShowModal(null);
           }}
           onChange={() => {}}
-          selectedValue={showModal === "from" ? addressFrom?.roadAddress || "" : addressTo?.roadAddress || ""}
+          selectedAddress={showModal === "from" ? addressFrom : addressTo}
         />
       )}
     </div>

--- a/src/app/(protected)/customer/estimate-request/MobileEstimateForm.tsx
+++ b/src/app/(protected)/customer/estimate-request/MobileEstimateForm.tsx
@@ -5,7 +5,7 @@ import MoveTypeCard from "./_components/card/MoveTypeCard";
 import MobileDatePicker from "./_components/datepicker/MobileDatePicker";
 import AddressCardModal from "./_components/modal/AddressCardModal";
 import Button from "@/components/Button";
-import { AddressSummary } from "@/utills/AddressSummary";
+import { AddressSummary } from "@/utills/AddressMapper";
 import { Address } from "@/types/Address";
 
 const moveTypes = [
@@ -167,7 +167,7 @@ export default function MobileEstimateForm() {
             setShowModal(null);
           }}
           onChange={() => {}}
-          selectedValue={showModal === "from" ? addressFrom?.roadAddress || "" : addressTo?.roadAddress || ""}
+          selectedAddress={showModal === "from" ? addressFrom : addressTo}
         />
       )}
     </main>

--- a/src/app/(protected)/customer/estimate-request/_components/modal/AddressCardModal.tsx
+++ b/src/app/(protected)/customer/estimate-request/_components/modal/AddressCardModal.tsx
@@ -13,7 +13,7 @@ interface AddressCardModalProps {
   onConfirm: (address: Address) => void;
   confirmLabel: string;
   onChange: (value: string) => void;
-  selectedValue: string;
+  selectedAddress?: Address | null;
 }
 
 export default function AddressCardModal({
@@ -21,7 +21,7 @@ export default function AddressCardModal({
   onClose,
   confirmLabel,
   onConfirm,
-  selectedValue
+  selectedAddress
 }: AddressCardModalProps) {
   const [inputValue, setInputValue] = useState("");
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -30,11 +30,14 @@ export default function AddressCardModal({
 
   // 선택된 주소를 외부로 전달
   useEffect(() => {
-    const index = addressList.findIndex((addr) => addr.roadAddress === selectedValue);
-    if (index !== -1) {
-      setSelectedIndex(index);
+    if (selectedAddress) {
+      setAddressList([selectedAddress]);
+      setSelectedIndex(0);
+    } else {
+      setAddressList([]);
+      setSelectedIndex(null);
     }
-  }, [selectedValue]);
+  }, [selectedAddress]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#141414]/40">
@@ -134,8 +137,8 @@ export default function AddressCardModal({
               jibunAddress: addr.jibunAddress
             };
 
-            setAddressList((prev) => [...prev, newAddress]);
-            setSelectedIndex(addressList.length);
+            setAddressList((prev) => [newAddress, ...prev]);
+            setSelectedIndex(0);
           }}
         />
       )}

--- a/src/lib/api/api-estimateRequest.ts
+++ b/src/lib/api/api-estimateRequest.ts
@@ -1,0 +1,37 @@
+import { cookieFetch } from "../FetchClient";
+
+// 주소 등록
+export async function createAddress(data: {
+  postalCode: string;
+  street: string;
+  detail?: string;
+  region: string;
+  district: string;
+}) {
+  return cookieFetch("/address", {
+    method: "POST",
+    body: JSON.stringify(data)
+  });
+}
+
+// 고객 주소 연결
+export async function linkCustomerAddress(data: { customerId: string; addressId: string; role: "FROM" | "TO" }) {
+  return cookieFetch("/customer/address", {
+    method: "POST",
+    body: JSON.stringify(data)
+  });
+}
+
+// 견적 요청 생성
+export async function createEstimateRequest(data: {
+  customerId: string;
+  moveType: string;
+  moveDate: string;
+  fromAddressId: string;
+  toAddressId: string;
+}) {
+  return cookieFetch("/customer/estimate-request", {
+    method: "POST",
+    body: JSON.stringify(data)
+  });
+}

--- a/src/types/Address.ts
+++ b/src/types/Address.ts
@@ -1,6 +1,26 @@
+// 우편번호 서비스 UI용 주소 타입
 export interface Address {
-  id: number;
+  id: number; //TODO: 추후 string으로 변경해야 함.
   postalCode: string;
   roadAddress: string;
   jibunAddress: string;
 }
+
+export type RegionType =
+  | "SEOUL"
+  | "BUSAN"
+  | "DAEGU"
+  | "INCHEON"
+  | "GWANGJU"
+  | "DAEJEON"
+  | "ULSAN"
+  | "SEJONG"
+  | "GYEONGGI"
+  | "GANGWON"
+  | "CHUNGBUK"
+  | "CHUNGNAM"
+  | "JEONBUK"
+  | "JEONNAM"
+  | "GYEONGBUK"
+  | "GYEONGNAM"
+  | "JEJU";

--- a/src/utills/AddressMapper.tsx
+++ b/src/utills/AddressMapper.tsx
@@ -1,0 +1,47 @@
+import { RegionType } from "@/types/Address";
+
+// 카카오 → 백엔드 스키마 변환 함수
+export function formatAddress(data: {
+  zonecode: string;
+  roadAddress: string;
+  jibunAddress?: string;
+  buildingName?: string;
+}) {
+  const regionMap: Record<string, RegionType> = {
+    서울: "SEOUL",
+    경기: "GYEONGGI",
+    부산: "BUSAN",
+    대구: "DAEGU",
+    인천: "INCHEON",
+    광주: "GWANGJU",
+    대전: "DAEJEON",
+    울산: "ULSAN",
+    세종: "SEJONG",
+    강원: "GANGWON",
+    충북: "CHUNGBUK",
+    충남: "CHUNGNAM",
+    전북: "JEONBUK",
+    전남: "JEONNAM",
+    경북: "GYEONGBUK",
+    경남: "GYEONGNAM",
+    제주: "JEJU"
+  };
+
+  const roadParts = data.roadAddress.split(" ");
+  const regionKo = roadParts[0];
+  const district = roadParts[1];
+
+  return {
+    postalCode: data.zonecode,
+    street: data.buildingName ? `${data.roadAddress} (${data.buildingName})` : data.roadAddress,
+    detail: "",
+    region: regionMap[regionKo] || "SEOUL",
+    district
+  };
+}
+
+// 빌딩(아파트) 이름 제거 유틸 함수
+export const AddressSummary = (fullAddress: string) => {
+  const parts = fullAddress.split(" ");
+  return parts.length >= 4 ? `${parts[0]} ${parts[1]} ${parts[2]} ${parts[3]}` : fullAddress;
+};

--- a/src/utills/AddressSummary.tsx
+++ b/src/utills/AddressSummary.tsx
@@ -1,4 +1,0 @@
-export const AddressSummary = (fullAddress: string) => {
-  const parts = fullAddress.split(" ");
-  return parts.length >= 4 ? `${parts[0]} ${parts[1]} ${parts[2]} ${parts[3]}` : fullAddress;
-};


### PR DESCRIPTION
## 📝작업 내용
- **AddressMapper 추가**
   - 기존 `AddressSummary.tsx` 삭제
   - `AddressMapper.tsx` 신규 작성, 백엔드 스키마에 맞게 변환 로직 구현
- **주소 등록 및 견적 요청 생성 API 연동**
   - profile 작업 끝나면 customerId 받아서 연결해야 함.
- **모달 상태 관리 개선**
   - `AddressCardModal`에서 `setAddress` 호출 시 선택된 주소값이 즉시 상태에 반영되도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
