### PR TITLE
[fix 이지수]기사 및 고객 수정 페이지 오류 해결

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -8,9 +8,18 @@ interface ButtonType {
   className?: string;
   isDisabled?: boolean;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  buttonType?: "button" | "submit"; // 버튼 타입 추가
 }
 
-function Button({ text, type, image = false, className = "w-full", isDisabled = false, onClick }: ButtonType) {
+function Button({
+  text,
+  type,
+  image = false,
+  className = "w-full",
+  isDisabled = false,
+  onClick,
+  buttonType = "submit" //수정
+}: ButtonType) {
   let color = "";
   if (type === "gray" || isDisabled) {
     color = "bg-gray-100 text-white";
@@ -26,6 +35,7 @@ function Button({ text, type, image = false, className = "w-full", isDisabled = 
 
   return (
     <button
+      type={buttonType} //수정
       disabled={isDisabled}
       onClick={onClick}
       className={`flex cursor-pointer items-center justify-center gap-[6px] rounded-[16px] py-[14px] font-semibold md:py-[17px] md:text-lg ${color} ${className}`}

--- a/src/components/profile/DriverProfileForm.tsx
+++ b/src/components/profile/DriverProfileForm.tsx
@@ -41,9 +41,7 @@ export default function DriverProfileForm({ isEditMode, initialData }: DriverPro
       setCareer(String(profileData.career ?? ""));
       setShortIntro(profileData.shortIntro || "");
       setDetailIntro(profileData.detailIntro || "");
-      const initialServiceAreas = profileData.serviceAreas
-        ?.map((area: { region: string }) => regionMapReverse[area.region])
-        .filter(Boolean);
+      const initialServiceAreas = profileData.serviceAreas?.map((area: { region: string }) => area.region);
       setSelectedRegions(initialServiceAreas || []);
     }
   }, [isEditMode, initialData]);
@@ -254,8 +252,11 @@ export default function DriverProfileForm({ isEditMode, initialData }: DriverPro
             <Button
               text="취소"
               type="gray"
-              className="h-15 w-full rounded-2xl bg-gray-200 text-lg font-semibold text-gray-700 md:w-[full]"
-              onClick={() => router.push("/driver/my-page")}
+              buttonType="button" //  폼 제출 안 됨
+              className="h-15 w-full rounded-2xl bg-gray-200 text-lg font-semibold text-gray-700 md:w-full" // md:w-[full] → md:w-full로 수정
+              onClick={() => {
+                router.push("/driver/my-page");
+              }}
             />
             <Button
               text={isSubmitting ? "제출 중..." : "수정하기"}


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 기사랑 고객 프로필 수정창에서 취소 눌렀을때 버튼 컴포넌트에 submit 속성밖에없어서 취소해도 제출되어버려서 버튼 컴포넌트에 button 속성 추가하고 취소하면 뒤로 돌아가게 만들었습니다.

2. 기사페이지  수정 지역 오류나는거 수정했습니다.

3. 고객 페이지에서 비밀번호 변경하는거 겉으로는 제출되고 안되고있었는데 고쳐서 작동하게 만들고 유효성 검사 빠져있었는데 추가했습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
