### PR TITLE
Fix: 견적 요청 시 moveType 전송 오류 수정

### DIFF
--- a/src/app/[locale]/(protected)/customer/estimate-request/DesktopEstimateForm.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/DesktopEstimateForm.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createEstimateRequest } from "@/lib/api/api-estimateRequest";
-import { moveTypeValueMap } from "@/types/moveType";
 import CalenderDropdown from "./_components/dropdown/CalenderDropdown";
 import MoveTypeCard from "./_components/card/MoveTypeCard";
 import AddressCardModal from "./_components/modal/AddressCardModal";
@@ -15,19 +14,20 @@ import { useTranslations } from "next-intl";
 export default function DesktopEstimateForm() {
   const t = useTranslations("EstimateReq");
   const moveTypes = [
-    { label: t("smallBox.text"), description: t("smallBox.subText") },
-    { label: t("familyBox.text"), description: t("familyBox.subText") },
-    { label: t("officeBox.text"), description: t("officeBox.subText") }
-  ];
+    { key: "SMALL", label: t("smallBox.text"), description: t("smallBox.subText") },
+    { key: "HOME", label: t("familyBox.text"), description: t("familyBox.subText") },
+    { key: "OFFICE", label: t("officeBox.text"), description: t("officeBox.subText") }
+  ] as const;
   const queryClient = useQueryClient();
-  const [selectedMoveType, setSelectedMoveType] = useState<string | null>(null);
+  type MoveTypeKey = (typeof moveTypes)[number]["key"];
+  const [selectedMoveType, setSelectedMoveType] = useState<MoveTypeKey | null>(null);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [showModal, setShowModal] = useState<"from" | "to" | null>(null);
   const [addressFrom, setAddressFrom] = useState<Address | null>(null);
   const [addressTo, setAddressTo] = useState<Address | null>(null);
 
-  const handleMoveTypeSelect = (label: string) => {
-    setSelectedMoveType((prev) => (prev === label ? null : label));
+  const handleMoveTypeSelect = (key: "SMALL" | "HOME" | "OFFICE") => {
+    setSelectedMoveType((prev) => (prev === key ? null : key));
   };
 
   const isFormValid = selectedMoveType !== null && selectedDate !== null && addressFrom !== null && addressTo !== null;
@@ -44,7 +44,7 @@ export default function DesktopEstimateForm() {
 
     try {
       await requestEstimate({
-        moveType: moveTypeValueMap[selectedMoveType],
+        moveType: selectedMoveType,
         moveDate: selectedDate.toISOString(),
         fromAddressId: String(addressFrom.id),
         toAddressId: String(addressTo.id)
@@ -70,13 +70,13 @@ export default function DesktopEstimateForm() {
           <div className="lg mb-12 flex flex-col gap-2">
             <p className="text-lg font-bold">{t("movingType")}</p>
             <div className="flex flex-row gap-3 lg:gap-4">
-              {moveTypes.map(({ label, description }) => (
+              {moveTypes.map(({ key, label, description }) => (
                 <MoveTypeCard
-                  key={label}
+                  key={key}
                   label={label}
                   description={description}
-                  selected={selectedMoveType === label}
-                  onClick={() => handleMoveTypeSelect(label)}
+                  selected={selectedMoveType === key}
+                  onClick={() => handleMoveTypeSelect(key)}
                 />
               ))}
             </div>

--- a/src/app/[locale]/(protected)/customer/estimate-request/MobileEstimateForm.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/MobileEstimateForm.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createEstimateRequest } from "@/lib/api/api-estimateRequest";
-import { moveTypeValueMap } from "@/types/moveType";
 import MoveTypeCard from "./_components/card/MoveTypeCard";
 import MobileDatePicker from "./_components/datepicker/MobileDatePicker";
 import AddressCardModal from "./_components/modal/AddressCardModal";
@@ -15,14 +14,16 @@ import { useTranslations } from "next-intl";
 export default function MobileEstimateForm() {
   const t = useTranslations("EstimateReq");
   const moveTypes = [
-    { label: t("smallBox.text"), description: t("smallBox.subText") },
-    { label: t("familyBox.text"), description: t("familyBox.subText") },
-    { label: t("officeBox.text"), description: t("officeBox.subText") }
-  ];
+    { key: "SMALL", label: t("smallBox.text"), description: t("smallBox.subText") },
+    { key: "HOME", label: t("familyBox.text"), description: t("familyBox.subText") },
+    { key: "OFFICE", label: t("officeBox.text"), description: t("officeBox.subText") }
+  ] as const;
+
   const queryClient = useQueryClient();
 
   const [step, setStep] = useState(1);
-  const [moveType, setMoveType] = useState<string | null>(null);
+  type MoveTypeKey = (typeof moveTypes)[number]["key"];
+  const [moveType, setMoveType] = useState<MoveTypeKey | null>(null);
   const [moveDate, setMoveDate] = useState<Date | null>(null);
   const [addressFrom, setAddressFrom] = useState<Address | null>(null);
   const [addressTo, setAddressTo] = useState<Address | null>(null);
@@ -41,8 +42,8 @@ export default function MobileEstimateForm() {
     }
   });
 
-  const handleMoveTypeSelect = (label: string) => {
-    setMoveType((prev) => (prev === label ? null : label));
+  const handleMoveTypeSelect = (key: MoveTypeKey) => {
+    setMoveType((prev) => (prev === key ? null : key));
   };
 
   const handleRequest = async () => {
@@ -50,7 +51,7 @@ export default function MobileEstimateForm() {
 
     try {
       await requestEstimate({
-        moveType: moveTypeValueMap[moveType],
+        moveType: moveType,
         moveDate: moveDate.toISOString(),
         fromAddressId: String(addressFrom.id),
         toAddressId: String(addressTo.id)
@@ -88,13 +89,13 @@ export default function MobileEstimateForm() {
           <div className="w-[327px]">
             {/* 이동 유형 카드 */}
             <div className="flex flex-col gap-4">
-              {moveTypes.map(({ label, description }) => (
+              {moveTypes.map(({ key, label, description }) => (
                 <MoveTypeCard
-                  key={label}
+                  key={key}
                   label={label}
                   description={description}
-                  selected={moveType === label}
-                  onClick={() => handleMoveTypeSelect(label)}
+                  selected={moveType === key}
+                  onClick={() => handleMoveTypeSelect(key)}
                 />
               ))}
             </div>


### PR DESCRIPTION
## 📝작업 내용
- moveType을 label을 문자열("기업, 사무실이사")로 저장한 후  enum key("OFFICE")로 매핑할 때 오류가 발생한 것 같습니다.
- moveTypes 배열에서 key와 label을 같이 정의해 매핑없이 사용하도록 수정했습니다.
  - 추후 리팩토링 예정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
