### PR TITLE
fix: 주소 모달 번역키 누락문제 해결 및 토스트 알림 리팩토링

### DIFF
--- a/src/app/[locale]/(protected)/customer/estimate-request/DesktopEstimateForm.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/DesktopEstimateForm.tsx
@@ -10,6 +10,7 @@ import Button from "@/components/Button";
 import { AddressSummary } from "@/utills/AddressMapper";
 import { Address } from "@/types/Address";
 import { useTranslations } from "next-intl";
+import { ToastModal } from "@/components/common-modal/ToastModal";
 
 export default function DesktopEstimateForm() {
   const t = useTranslations("EstimateReq");
@@ -49,9 +50,9 @@ export default function DesktopEstimateForm() {
         fromAddressId: String(addressFrom.id),
         toAddressId: String(addressTo.id)
       });
-      alert(t("estimateReqSuccess"));
+      ToastModal(t("estimateReqSuccess"));
     } catch {
-      alert(t("estimateReqFailure"));
+      ToastModal(t("estimateReqFailure"));
     }
   };
 

--- a/src/app/[locale]/(protected)/customer/estimate-request/MobileEstimateForm.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/MobileEstimateForm.tsx
@@ -10,6 +10,7 @@ import Button from "@/components/Button";
 import { AddressSummary } from "@/utills/AddressMapper";
 import { Address } from "@/types/Address";
 import { useTranslations } from "next-intl";
+import { ToastModal } from "@/components/common-modal/ToastModal";
 
 export default function MobileEstimateForm() {
   const t = useTranslations("EstimateReq");
@@ -56,9 +57,9 @@ export default function MobileEstimateForm() {
         fromAddressId: String(addressFrom.id),
         toAddressId: String(addressTo.id)
       });
-      alert(t("estimateReqSuccess"));
+      ToastModal(t("estimateReqSuccess"));
     } catch {
-      alert(t("estimateReqFailure"));
+      ToastModal(t("estimateReqFailure"));
     }
   };
 
@@ -197,7 +198,7 @@ export default function MobileEstimateForm() {
       {/* 주소 검색 모달 */}
       {showModal && (
         <AddressCardModal
-          title={showModal === "from" ? t("fromSelect") : t("toSelect")}
+          title={showModal === "from" ? t("fromChoose") : t("toChoose")}
           confirmLabel={t("confirm")}
           onClose={() => setShowModal(null)}
           onConfirm={(value: Address) => {


### PR DESCRIPTION
## 📝작업 내용
- 모바일 환경에서 주소 모달 타이틀 안 뜨는 문제 해결했습니다.
- alert 알림을 토스트 모달로 교체했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
