### PR TITLE
feat: 견적 요청 페이지 다국어 적용 및 Lottie 로딩 UI 개선

### DIFF
--- a/src/app/[locale]/(protected)/customer/estimate-request/DisabledForm.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/DisabledForm.tsx
@@ -2,34 +2,36 @@
 
 import Button from "@/components/Button";
 import PageHeader from "@/components/common/PageHeader";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 export default function EstimateRequestDisabled() {
   const router = useRouter();
+  const t = useTranslations("EstimateReq");
 
   return (
     <>
-      <PageHeader title="견적 요청" />
+      <PageHeader title={t("disabled.title")} />
       <main className="bg-background-200 flex min-h-screen items-center justify-center">
         <div className="flex flex-col items-center gap-12 lg:gap-8">
           <div className="flex flex-col items-center">
             <Image
               src="/assets/images/img_moving_car.png"
-              alt="견적 불가"
+              alt={t("disabled.imageAlt")}
               width={180}
               height={180}
               className="opacity-30 grayscale lg:w-70"
             />
 
             <p className="text-center text-sm text-gray-400 lg:text-xl">
-              현재 진행 중인 이사 견적이 있어요! <br />
-              진행 중인 이사 완료 후 새로운 견적을 받아보세요.
+              {t("disabled.message.line1")} <br />
+              {t("disabled.message.line2")}
             </p>
           </div>
           <Button
             onClick={() => router.push("/customer/my-estimates")}
-            text="받은 견적 보러가기"
+            text={t("disabled.button")}
             type="orange"
             className="h-[54px] !px-6 !py-4 !text-base lg:!text-lg"
           />

--- a/src/app/[locale]/(protected)/customer/estimate-request/MobileEstimateForm.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/MobileEstimateForm.tsx
@@ -11,6 +11,7 @@ import { AddressSummary } from "@/utills/AddressMapper";
 import { Address } from "@/types/Address";
 import { useTranslations } from "next-intl";
 import { ToastModal } from "@/components/common-modal/ToastModal";
+import LoadingLottie from "@/components/lottie/LoadingLottie";
 
 export default function MobileEstimateForm() {
   const t = useTranslations("EstimateReq");
@@ -29,6 +30,7 @@ export default function MobileEstimateForm() {
   const [addressFrom, setAddressFrom] = useState<Address | null>(null);
   const [addressTo, setAddressTo] = useState<Address | null>(null);
   const [showModal, setShowModal] = useState<"from" | "to" | null>(null);
+  const [isRequesting, setIsRequesting] = useState(false);
 
   const isValidStep1 = !!moveType;
   const isValidStep2 = !!moveDate;
@@ -36,7 +38,7 @@ export default function MobileEstimateForm() {
 
   const stepList = [1, 2, 3];
 
-  const { mutateAsync: requestEstimate, isPending } = useMutation({
+  const { mutateAsync: requestEstimate } = useMutation({
     mutationFn: createEstimateRequest,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["estimate", "active"] });
@@ -51,6 +53,7 @@ export default function MobileEstimateForm() {
     if (!moveType || !moveDate || !addressFrom || !addressTo) return;
 
     try {
+      setIsRequesting(true);
       await requestEstimate({
         moveType: moveType,
         moveDate: moveDate.toISOString(),
@@ -60,8 +63,14 @@ export default function MobileEstimateForm() {
       ToastModal(t("estimateReqSuccess"));
     } catch {
       ToastModal(t("estimateReqFailure"));
+    } finally {
+      setIsRequesting(false);
     }
   };
+
+  if (isRequesting) {
+    return <LoadingLottie text="견적 요청 진행중입니다." />;
+  }
 
   return (
     <main className="mt-[90px] min-h-screen justify-center bg-white px-6">
@@ -185,9 +194,9 @@ export default function MobileEstimateForm() {
             />
 
             <Button
-              isDisabled={!isValidStep3 || isPending}
+              isDisabled={!isValidStep3}
               onClick={handleRequest}
-              text={isPending ? t("requesting") : t("requestEstimate")}
+              text={t("requestEstimate")}
               type="orange"
               className="h-[54px] w-[158px]"
             />

--- a/src/app/[locale]/(protected)/customer/estimate-request/_components/card/AddressResultCard.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/_components/card/AddressResultCard.tsx
@@ -1,5 +1,6 @@
 import ChipCircle from "@/components/chip/ChipCircle";
 import clsx from "clsx";
+import { useTranslations } from "next-intl";
 
 interface AddressResultCardProps {
   postalCode: string;
@@ -16,6 +17,7 @@ export default function AddressResultCard({
   selected = false,
   onClick
 }: AddressResultCardProps) {
+  const t = useTranslations("Chip");
   return (
     <div
       onClick={onClick}
@@ -30,12 +32,12 @@ export default function AddressResultCard({
       <div className="flex flex-col gap-4 text-sm md:text-base">
         <p className="text-black-400 text-sm font-semibold md:text-base">{postalCode}</p>
         <div className="flex items-start gap-2">
-          <ChipCircle type="address" color="orange" text="도로명" />
+          <ChipCircle type="address" color="orange" text={t("road")} />
           <p className="max-w-[176px] break-words whitespace-pre-wrap text-black md:max-w-full">{roadAddress}</p>
         </div>
 
         <div className="flex items-start gap-2">
-          <ChipCircle type="address" color="orange" text="지번" />
+          <ChipCircle type="address" color="orange" text={t("jibun")} />
           <p className="max-w-[176px] break-words whitespace-pre-wrap text-black md:max-w-full">{jibunAddress}</p>
         </div>
       </div>

--- a/src/app/[locale]/(protected)/customer/estimate-request/_components/card/MoveTypeCard.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/_components/card/MoveTypeCard.tsx
@@ -56,6 +56,7 @@ export default function MoveTypeCard({ label, description, selected, onClick }: 
           alt={label}
           width={120}
           height={120}
+          priority
           unoptimized
           className="self-center object-contain md:mt-auto md:self-end"
         />

--- a/src/app/[locale]/(protected)/customer/estimate-request/_components/datepicker/DatePicker.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/_components/datepicker/DatePicker.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import Image from "next/image";
 import clsx from "clsx";
-import { generateCalendarDates } from "@/utills/dateUtils";
+import { generateCalendarDates, setDayjsLocale } from "@/utills/dateUtils";
+import { useLocale, useTranslations } from "next-intl";
 
 interface DateProps {
   selectedDate: Date | null;
@@ -13,10 +14,16 @@ interface DateProps {
 }
 
 function DatePicker({ selectedDate, onSelectDate, onConfirm }: DateProps) {
+  const t = useTranslations("Date");
+  const locale = useLocale();
   const today = dayjs();
   const [current, setCurrent] = useState(dayjs());
 
-  const days = ["일", "월", "화", "수", "목", "금", "토"];
+  useEffect(() => {
+    setDayjsLocale(locale);
+  }, [locale]);
+
+  const days = [t("day.sun"), t("day.mon"), t("day.tue"), t("day.wed"), t("day.thu"), t("day.fri"), t("day.sat")];
 
   const gridDates = generateCalendarDates(current);
 
@@ -28,12 +35,20 @@ function DatePicker({ selectedDate, onSelectDate, onConfirm }: DateProps) {
     <div className="flex h-full w-full flex-col justify-between rounded-2xl border border-[var(--color-line-200)] bg-white px-[45.5px] py-8 shadow-md">
       {/* 헤더 */}
       <div className="mb-[13px] flex items-center justify-between">
-        <button onClick={() => setCurrent((prev) => prev.subtract(1, "month"))} aria-label="이전 달" className="p-2">
-          <Image src="/assets/icons/ic_chevron_left.svg" alt="이전 달" width={24} height={24} />
+        <button
+          onClick={() => setCurrent((prev) => prev.subtract(1, "month"))}
+          aria-label={t("label.prevMonth")}
+          className="p-2"
+        >
+          <Image src="/assets/icons/ic_chevron_left.svg" alt={t("label.prevMonth")} width={24} height={24} />
         </button>
         <div className="text-lg font-bold text-black">{current.format("YYYY. MM")}</div>
-        <button onClick={() => setCurrent((prev) => prev.add(1, "month"))} aria-label="다음 달" className="p-2">
-          <Image src="/assets/icons/ic_chevron_right.svg" alt="다음 달" width={24} height={24} />
+        <button
+          onClick={() => setCurrent((prev) => prev.add(1, "month"))}
+          aria-label={t("label.nextMonth")}
+          className="p-2"
+        >
+          <Image src="/assets/icons/ic_chevron_right.svg" alt={t("label.nextMonth")} width={24} height={24} />
         </button>
       </div>
 
@@ -69,7 +84,7 @@ function DatePicker({ selectedDate, onSelectDate, onConfirm }: DateProps) {
               </button>
             </div>
           );
-        })}
+        })}{" "}
       </div>
 
       {/* 선택완료 버튼 */}
@@ -82,7 +97,7 @@ function DatePicker({ selectedDate, onSelectDate, onConfirm }: DateProps) {
             selectedDate ? "bg-[var(--color-orange-400)]" : "bg-gray-100"
           )}
         >
-          선택완료
+          {t("button.confirm")}
         </button>
       </div>
     </div>

--- a/src/app/[locale]/(protected)/customer/estimate-request/_components/datepicker/MobileDatePicker.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/_components/datepicker/MobileDatePicker.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import dayjs from "dayjs";
 import clsx from "clsx";
 import Image from "next/image";
-import { generateCalendarDates } from "@/utills/dateUtils";
+import { generateCalendarDates, setDayjsLocale } from "@/utills/dateUtils";
+import { useLocale, useTranslations } from "use-intl";
 
 interface MobileDatePickerProps {
   selectedDate: Date | null;
@@ -12,10 +13,16 @@ interface MobileDatePickerProps {
 }
 
 export default function MobileDatePicker({ selectedDate, onSelectDate }: MobileDatePickerProps) {
+  const t = useTranslations("Date");
+  const locale = useLocale();
   const today = dayjs();
   const [current, setCurrent] = useState(dayjs());
 
-  const days = ["일", "월", "화", "수", "목", "금", "토"];
+  useEffect(() => {
+    setDayjsLocale(locale);
+  }, [locale]);
+
+  const days = [t("day.sun"), t("day.mon"), t("day.tue"), t("day.wed"), t("day.thu"), t("day.fri"), t("day.sat")];
 
   const gridDates = generateCalendarDates(current);
 

--- a/src/app/[locale]/(protected)/customer/estimate-request/_components/dropdown/CalenderDropdown.tsx
+++ b/src/app/[locale]/(protected)/customer/estimate-request/_components/dropdown/CalenderDropdown.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocale } from "use-intl";
 import Image from "next/image";
 import clsx from "clsx";
 import DatePicker from "../datepicker/DatePicker";
@@ -11,7 +12,9 @@ interface CalenderDropdownProps {
 function CalenderDropdown({ date, onChange }: CalenderDropdownProps) {
   const [open, setOpen] = useState(false);
 
-  const formatted = (date ?? new Date()).toLocaleDateString("ko-KR", {
+  const locale = useLocale();
+
+  const formatted = (date ?? new Date()).toLocaleDateString(locale, {
     year: "numeric",
     month: "long",
     day: "numeric"

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -17,6 +17,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
     FindDriver: (await import(`../messages/${locale}/FindDriver.json`)).default,
     Gnb: (await import(`../messages/${locale}/Gnb.json`)).default,
     Chip: (await import(`../messages/${locale}/Chip.json`)).default,
+    Date: (await import(`../messages/${locale}/Date.json`)).default,
     //고객
     EstimateReq: (await import(`../messages/${locale}/EstimateReq.json`)).default,
     MyEstimates: (await import(`../messages/${locale}/MyEstimates.json`)).default,

--- a/src/messages/en/Chip.json
+++ b/src/messages/en/Chip.json
@@ -2,5 +2,7 @@
   "SMALL": "Small Move",
   "HOME": "Home Move",
   "OFFICE": "Office Move",
-  "REQUEST": "Custom Quote Request"
+  "REQUEST": "Custom Quote Request",
+  "road": "Rd",
+  "jibun": "Land lot"
 }

--- a/src/messages/en/Date.json
+++ b/src/messages/en/Date.json
@@ -1,0 +1,23 @@
+{
+  "day": {
+    "sun": "Sun",
+    "mon": "Mon",
+    "tue": "Tue",
+    "wed": "Wed",
+    "thu": "Thu",
+    "fri": "Fri",
+    "sat": "Sat"
+  },
+  "button": {
+    "confirm": "Confirm"
+  },
+  "label": {
+    "prevMonth": "Previous month",
+    "nextMonth": "Next month",
+    "prev": "Previous",
+    "next": "Next"
+  },
+  "format": {
+    "yearMonth": "YYYY. MM"
+  }
+}

--- a/src/messages/en/EstimateReq.json
+++ b/src/messages/en/EstimateReq.json
@@ -32,5 +32,14 @@
   "estimateReqFailure": "Quote request failed. Please try again.",
   "previous": "Previous",
   "next": "Next",
-  "close": "Close"
+  "close": "Close",
+  "disabled": {
+    "title": "Estimate Request",
+    "imageAlt": "Estimate Unavailable",
+    "message": {
+      "line1": "You already have an active estimate request!",
+      "line2": "Please complete your ongoing move before making a new request."
+    },
+    "button": "View Received Estimates"
+  }
 }

--- a/src/messages/ko/Chip.json
+++ b/src/messages/ko/Chip.json
@@ -2,5 +2,7 @@
   "SMALL": "소형이사",
   "HOME": "가정이사",
   "OFFICE": "사무실이사",
-  "REQUEST": "지정 견적 요청"
+  "REQUEST": "지정 견적 요청",
+  "road": "도로명",
+  "jibun": "지번"
 }

--- a/src/messages/ko/Date.json
+++ b/src/messages/ko/Date.json
@@ -1,0 +1,23 @@
+{
+  "day": {
+    "sun": "일",
+    "mon": "월",
+    "tue": "화",
+    "wed": "수",
+    "thu": "목",
+    "fri": "금",
+    "sat": "토"
+  },
+  "button": {
+    "confirm": "선택완료"
+  },
+  "label": {
+    "prevMonth": "이전 달",
+    "nextMonth": "다음 달",
+    "prev": "이전",
+    "next": "다음"
+  },
+  "format": {
+    "yearMonth": "YYYY. MM"
+  }
+}

--- a/src/messages/ko/EstimateReq.json
+++ b/src/messages/ko/EstimateReq.json
@@ -32,5 +32,14 @@
   "estimateReqFailure": "견적 요청에 실패했습니다.",
   "previous": "이전",
   "next": "다음",
-  "close": "닫기"
+  "close": "닫기",
+  "disabled": {
+    "title": "견적 요청",
+    "imageAlt": "견적 불가",
+    "message": {
+      "line1": "현재 진행 중인 이사 견적이 있어요!",
+      "line2": "진행 중인 이사 완료 후 새로운 견적을 받아보세요."
+    },
+    "button": "받은 견적 보러가기"
+  }
 }

--- a/src/messages/zh/Chip.json
+++ b/src/messages/zh/Chip.json
@@ -2,5 +2,7 @@
   "SMALL": "小型搬家",
   "HOME": "家庭搬家",
   "OFFICE": "办公室搬家",
-  "REQUEST": "指定报价请求"
+  "REQUEST": "指定报价请求",
+  "road": "道路名",
+  "jibun": "地番"
 }

--- a/src/messages/zh/Date.json
+++ b/src/messages/zh/Date.json
@@ -1,0 +1,23 @@
+{
+  "day": {
+    "sun": "日",
+    "mon": "一",
+    "tue": "二",
+    "wed": "三",
+    "thu": "四",
+    "fri": "五",
+    "sat": "六"
+  },
+  "button": {
+    "confirm": "确认"
+  },
+  "label": {
+    "prevMonth": "上个月",
+    "nextMonth": "下个月",
+    "prev": "上一页",
+    "next": "下一页"
+  },
+  "format": {
+    "yearMonth": "YYYY年MM月"
+  }
+}

--- a/src/messages/zh/EstimateReq.json
+++ b/src/messages/zh/EstimateReq.json
@@ -32,5 +32,14 @@
   "estimateReqFailure": "报价请求失败。请再试一次。",
   "previous": "上一步",
   "next": "下一步",
-  "close": "关闭"
+  "close": "关闭",
+  "disabled": {
+    "title": "搬家估价请求",
+    "imageAlt": "无法请求估价",
+    "message": {
+      "line1": "您已有正在进行的搬家估价请求！",
+      "line2": "完成当前搬家后，才能再次申请估价。"
+    },
+    "button": "查看收到的估价"
+  }
 }

--- a/src/utills/dateUtils.tsx
+++ b/src/utills/dateUtils.tsx
@@ -11,7 +11,12 @@ import "dayjs/locale/ko"; // 한국어 로케일 파일 불러옴
 dayjs.extend(relativeTime);
 
 // 기본 로케일을 한국어로 설정
-dayjs.locale("ko");
+// dayjs.locale("ko");
+
+export const setDayjsLocale = (locale: string) => {
+  const supported = ["ko", "en", "zh"];
+  dayjs.locale(supported.includes(locale) ? locale : "ko");
+};
 
 export interface CalendarDate {
   date: Date;


### PR DESCRIPTION
## 📝작업 내용
- 견적 요청 페이지 다국어 적용 (disabledForm, DatePicker, AddressCard)
- LoadingLottie 컴포넌트 적용

### 스크린샷 (선택)
<img width="262" height="306" alt="스크린샷 2025-07-31 오후 5 48 14" src="https://github.com/user-attachments/assets/3ead5f65-ab10-48a3-a71b-9db470b25cbd" />
<img width="404" height="521" alt="스크린샷 2025-07-31 오후 5 49 05" src="https://github.com/user-attachments/assets/99d97de0-dfe2-47b2-badc-1426cae97506" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
