### PR TITLE
[Fix,Refactor 이지수] 로그인, middleware , AuthProvider 리팩토링

### DIFF
--- a/src/app/[locale]/(auth)/login/customer/page.tsx
+++ b/src/app/[locale]/(auth)/login/customer/page.tsx
@@ -4,12 +4,14 @@ import Link from "next/link";
 import Image from "next/image";
 import { useLoginForm } from "@/hooks/useAuthForm";
 import TextField from "@/components/input/TextField";
+import { UserType } from "@/types/UserType";
 import { ToastModal } from "@/components/common-modal/ToastModal";
 import { useEffect } from "react";
 
 export default function LoginCustomer() {
-  const { email, setEmail, password, setPassword, onSubmit, isEmailValid, isPasswordValid, isFormValid } =
-    useLoginForm();
+  const { email, setEmail, password, setPassword, onSubmit, isEmailValid, isPasswordValid, isFormValid } = useLoginForm(
+    UserType.CUSTOMER
+  );
 
   useEffect(() => {
     const signupSuccess = localStorage.getItem("signupSuccess");

--- a/src/app/[locale]/(auth)/login/driver/page.tsx
+++ b/src/app/[locale]/(auth)/login/driver/page.tsx
@@ -4,12 +4,14 @@ import Link from "next/link";
 import Image from "next/image";
 import { useLoginForm } from "@/hooks/useAuthForm";
 import TextField from "@/components/input/TextField";
+import { UserType } from "@/types/UserType";
 import { useEffect } from "react";
 import { ToastModal } from "@/components/common-modal/ToastModal";
 
 export default function LoginDriver() {
-  const { email, setEmail, password, setPassword, onSubmit, isEmailValid, isPasswordValid, isFormValid } =
-    useLoginForm();
+  const { email, setEmail, password, setPassword, onSubmit, isEmailValid, isPasswordValid, isFormValid } = useLoginForm(
+    UserType.DRIVER
+  );
 
   useEffect(() => {
     const signupSuccess = localStorage.getItem("signupSuccess");

--- a/src/components/profile/CustomerProfileEditForm.tsx
+++ b/src/components/profile/CustomerProfileEditForm.tsx
@@ -195,21 +195,39 @@ export default function CustomerProfileEditForm({ initialData }: CustomerProfile
           {/* 현재 비밀번호 */}
           <div className="mb-5 flex flex-col pt-5">
             <label className="mb-5 text-xl font-semibold">현재 비밀번호</label>
-            <TextField value={currentPassword} onChange={setCurrentPassword} type="password" mdHeight="54" />
+            <TextField
+              placeholder="현재 비밀번호를 입력해주세요"
+              value={currentPassword}
+              onChange={setCurrentPassword}
+              type="password"
+              mdHeight="54"
+            />
           </div>
           <div className="border-line-100 my-2.5 border-t" />
 
           {/* 새 비밀번호 */}
           <div className="mb-5 flex flex-col pt-5">
             <label className="mb-5 text-xl font-semibold">새 비밀번호</label>
-            <TextField value={newPassword} onChange={setNewPassword} type="password" mdHeight="54" />
+            <TextField
+              placeholder="새 비밀번호를 입력해주세요"
+              value={newPassword}
+              onChange={setNewPassword}
+              type="password"
+              mdHeight="54"
+            />
             {newPasswordError && <p className="mt-1 text-sm text-red-500">{newPasswordError}</p>}
           </div>
 
           {/* 새 비밀번호 확인 */}
           <div className="mb-5 flex flex-col pt-5">
             <label className="mb-5 text-xl font-semibold">새 비밀번호 확인</label>
-            <TextField value={confirmPassword} onChange={setConfirmPassword} type="password" mdHeight="54" />
+            <TextField
+              placeholder="새 비밀번호를 다시 입력해주세요"
+              value={confirmPassword}
+              onChange={setConfirmPassword}
+              type="password"
+              mdHeight="54"
+            />
           </div>
         </div>
 

--- a/src/hooks/useAuthForm.ts
+++ b/src/hooks/useAuthForm.ts
@@ -11,7 +11,7 @@ const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const PHONE_REGEX = /^010\d{8}$/;
 const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>/?]).{8,}$/;
 
-export function useLoginForm() {
+export function useLoginForm(userType: UserType) {
   const router = useRouter();
   const { user, login } = useAuth();
   const [email, setEmail] = useState("");
@@ -27,12 +27,12 @@ export function useLoginForm() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login(email, password);
+      await login(email, password, userType);
       // 로그인 성공하면 useEffect에서 user 상태 확인 후 라우팅 처리
     } catch (error: any) {
       console.error("Login failed:", error);
       const message = parseBackendError(error.status, error.message);
-      alert(message);
+      ToastModal(message);
     }
   };
 

--- a/src/lib/api/api-auth.ts
+++ b/src/lib/api/api-auth.ts
@@ -17,11 +17,11 @@ export const authService = {
     });
   },
 
-  logInUser: async (email: string, password: string): Promise<{ accessToken: string }> => {
+  logInUser: async (email: string, password: string, userType: UserType): Promise<{ accessToken: string }> => {
     try {
       const response = await defaultFetch("/auth/login", {
         method: "POST",
-        body: JSON.stringify({ email, password }),
+        body: JSON.stringify({ email, password, userType }),
         credentials: "include",
         cache: "no-store"
       });

--- a/src/providers/AuthProvider.tsx
+++ b/src/providers/AuthProvider.tsx
@@ -17,7 +17,7 @@ export type User = {
 type AuthContextType = {
   user: User | null;
   isLoading: boolean;
-  login: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string, userType: UserType) => Promise<void>;
   logout: () => Promise<void>;
   register: (data: {
     name: string;
@@ -78,9 +78,9 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const login = useCallback(
-    async (email: string, password: string) => {
+    async (email: string, password: string, userType: UserType) => {
       try {
-        await authService.logInUser(email, password);
+        await authService.logInUser(email, password, userType);
         await getUser();
       } catch (error) {
         console.error("로그인 실패:", error);


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

리팩토링

1. 로그인 api 에 유저타입을 추가하여 각 로그인 페이지에 맞는 계정만 로그인 가능하게 만듬

2. 비로그인 상태에서의 리프레쉬 토큰 갱신 에러 메시지 제거

3. 미들웨어 라우팅에 리프레쉬토큰 관련 로직 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
