### PR TITLE
fix: 도로명 주소 빌딩명 중복 표시 문제 수정

### DIFF
--- a/src/utills/AddressMapper.tsx
+++ b/src/utills/AddressMapper.tsx
@@ -33,8 +33,8 @@ export function formatAddress(data: {
 
   return {
     postalCode: data.postalcode,
-    street: data.buildingName ? `${data.roadAddress} (${data.buildingName})` : data.roadAddress,
-    detail: "",
+    street: data.roadAddress,
+    detail: data.buildingName || "",
     region: regionMap[regionKo] || "SEOUL",
     district
   };


### PR DESCRIPTION
## 📝작업 내용
- 주소 선택 시 `buildingName`이 이미 `roadAddress`에 포함되어 있는 경우 중복 표기되지 않도록 수정
- `AddressSummary` 함수에서 도로명만 요약되도록 로직 수정

### 스크린샷 (선택)
<img width="218" height="142" alt="스크린샷 2025-07-31 오후 10 43 49" src="https://github.com/user-attachments/assets/e0df579b-f332-4e74-b8a8-f94aa78c44c7" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
