### PR TITLE
[황수정] 로그인 버튼 다국어 관련 레이아웃 로직 수정

### DIFF
--- a/src/components/gnb/GnbMenuList.tsx
+++ b/src/components/gnb/GnbMenuList.tsx
@@ -66,7 +66,7 @@ export default function GnbMenuList({ browserWidth, userRole, onClick, isLg }: G
         >
           <span
             className={
-              label === "로그인"
+              label.includes(t("login"))
                 ? isLg || isLoggedIn
                   ? "hidden"
                   : "block"


### PR DESCRIPTION
## 📝작업 내용
- 로그인 버튼이 해상도에 따라 보이지 않도록 적용되어 있었음
- 다국어 반영 과정에서 적용되지 않는 현상이 발견되어 로직 수정
- 로그인 버튼에 label로 t("login)이 포함되어 있다면 로직이 적용되도록 수정
