### PR TITLE
[황수정] 알림 다국어 적용 보완

### DIFF
--- a/src/components/notification/NotificationDropdown.tsx
+++ b/src/components/notification/NotificationDropdown.tsx
@@ -296,7 +296,7 @@ export default function Notification({ ref, onClick, className, isOpen }: Notifi
           <ul className="overflow-y-auto scroll-smooth" role="list" aria-label={t("notificationList")}>
             {notifications.length === 0 ? (
               <li className="p-4 text-center text-gray-400" role="status" aria-live="polite">
-                t("hasNotUnread")
+                {t("hasNotUnread")}
               </li>
             ) : (
               notifications.map((item) => (


### PR DESCRIPTION
## 📝작업 내용
- 알림이 없을 경우 다국어 변수명이 그대로 노출되는 현상이 발견되어 수정했습니다.