### PR TITLE
[황수정] header 포지션 조정

### DIFF
--- a/src/app/[locale]/(protected)/customer/my-estimates/estimate-pending/_components/EstimateSubHeader.tsx
+++ b/src/app/[locale]/(protected)/customer/my-estimates/estimate-pending/_components/EstimateSubHeader.tsx
@@ -21,59 +21,63 @@ export default function EstimateSubHeader({ data }: EstimateSubHeaderProps) {
   const { label, requestDate, from, to, date } = data;
 
   return (
-    <div className="bg-white p-6 shadow-sm md:px-17 md:py-7 lg:px-90 lg:py-8">
-      <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-        {/* 왼쪽: 제목 + 신청일 */}
-        <div className="flex flex-col gap-1">
-          <h2 className="text-[20px] font-semibold text-black sm:text-[18px] md:text-[20px] lg:text-[24px]">{label}</h2>
-          <p className="text-sm text-gray-400 sm:text-xs md:text-sm">
-            {t("applicationDate")}: {requestDate}
-          </p>
-        </div>
+    <div className="flex items-center justify-center bg-white p-6 shadow-sm md:px-17 md:py-7 lg:px-90 lg:py-8">
+      <div className="flex w-full items-center justify-center lg:max-w-[1210px] lg:min-w-[855px]">
+        <div className="flex w-full flex-col gap-5 lg:min-w-[850px] lg:flex-row lg:items-center lg:justify-between xl:min-w-[1200px]">
+          {/* 왼쪽: 제목 + 신청일 */}
+          <div className="flex flex-1 flex-col gap-1">
+            <h2 className="text-[20px] font-semibold text-black sm:text-[18px] md:text-[20px] lg:text-[24px]">
+              {label}
+            </h2>
+            <p className="text-sm text-gray-400 sm:text-xs md:text-sm">
+              {t("applicationDate")}: {requestDate}
+            </p>
+          </div>
 
-        {/* lg, md 버전: 기존 레이아웃 유지 */}
-        <div className="hidden gap-10 text-sm md:flex lg:flex-row lg:items-end lg:justify-end lg:gap-12">
-          {/* 출발지 → 도착지 */}
-          <div className="flex items-end gap-10 text-sm md:flex-row lg:gap-5">
+          {/* lg, md 버전: 기존 레이아웃 유지 */}
+          <div className="hidden gap-10 text-sm md:flex lg:flex-row lg:items-end lg:justify-end lg:gap-12">
+            {/* 출발지 → 도착지 */}
+            <div className="flex items-end gap-10 text-sm md:flex-row lg:gap-5">
+              {/* 출발지 */}
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-gray-400 lg:text-sm">{t1("from")}</span>
+                <span className="text-base font-semibold text-black lg:text-lg">{from}</span>
+              </div>
+
+              {/* 화살표 */}
+              <img src="/assets/icons/ic_arrow_short.svg" alt="화살표" width={13} height={13} className="" />
+
+              {/* 도착지 */}
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-gray-400 lg:text-sm">{t1("to")}</span>
+                <span className="text-base font-semibold text-black lg:text-lg">{to}</span>
+              </div>
+            </div>
+
+            {/* 이사일 */}
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-gray-400 lg:text-sm">{t1("date")}</span>
+              <span className="text-sm font-semibold text-black lg:text-lg">{date}</span>
+            </div>
+          </div>
+
+          {/* sm 이하 전용 레이아웃 */}
+          <div className="flex flex-col gap-2 p-1 md:hidden">
             {/* 출발지 */}
-            <div className="flex flex-col gap-1">
-              <span className="text-xs text-gray-400 lg:text-sm">{t1("from")}</span>
-              <span className="text-base font-semibold text-black lg:text-lg">{from}</span>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-400">{t1("from")}</span>
+              <span className="text-sm font-semibold text-black">{from}</span>
             </div>
-
-            {/* 화살표 */}
-            <img src="/assets/icons/ic_arrow_short.svg" alt="화살표" width={13} height={13} className="" />
-
             {/* 도착지 */}
-            <div className="flex flex-col gap-1">
-              <span className="text-xs text-gray-400 lg:text-sm">{t1("to")}</span>
-              <span className="text-base font-semibold text-black lg:text-lg">{to}</span>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-400">{t1("to")}</span>
+              <span className="text-sm font-semibold text-black">{to}</span>
             </div>
-          </div>
-
-          {/* 이사일 */}
-          <div className="flex flex-col gap-1">
-            <span className="text-xs text-gray-400 lg:text-sm">{t1("date")}</span>
-            <span className="text-sm font-semibold text-black lg:text-lg">{date}</span>
-          </div>
-        </div>
-
-        {/* sm 이하 전용 레이아웃 */}
-        <div className="flex flex-col gap-2 p-1 md:hidden">
-          {/* 출발지 */}
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-gray-400">{t1("from")}</span>
-            <span className="text-sm font-semibold text-black">{from}</span>
-          </div>
-          {/* 도착지 */}
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-gray-400">{t1("to")}</span>
-            <span className="text-sm font-semibold text-black">{to}</span>
-          </div>
-          {/* 이사일 */}
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-gray-400">{t1("date")}</span>
-            <span className="text-sm font-semibold text-black">{date}</span>
+            {/* 이사일 */}
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-400">{t1("date")}</span>
+              <span className="text-sm font-semibold text-black">{date}</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,16 +44,19 @@ export default function Header({ type, selectedIdx, setSelectedIdx }: HeaderProp
   }));
 
   const SIZE_CLASSES = {
-    base: ["lg:px-90 lg:gap-8 lg:pt-4"],
-    sm: ["sm:gap-6 sm:px-6"],
-    md: ["md:gap-6 md:px-18"]
+    // base: [""],
+    // sm: ["sm: sm:px-6 sm:w-full"],
+    // md: ["md: md:px-18 md:w-full"]
+    base: ["lg:gap-8 lg:pt-4 "],
+    sm: ["sm:gap-6 "],
+    md: ["md:gap-6 "]
   };
 
   return (
-    <div>
+    <div className="border-line-100 flex items-center justify-center border-b-1 bg-gray-50 pb-0 shadow-[0px_2px_10px_rgba(248,248,248,0.10)]">
       <div
         className={clsx(
-          "border-line-100 flex items-start border-b-1 bg-gray-50 pb-0 shadow-[0px_2px_10px_rgba(248,248,248,0.10)]",
+          "flex w-full max-w-[var(--container-gnb)] min-w-[375px] flex-row items-start px-6 lg:pl-55 xl:pl-49",
           ...SIZE_CLASSES.base,
           ...SIZE_CLASSES.md,
           ...SIZE_CLASSES.sm

--- a/src/components/gnb/Gnb.tsx
+++ b/src/components/gnb/Gnb.tsx
@@ -11,6 +11,7 @@ import Button from "../Button";
 import { useRouter } from "next/navigation";
 import { OpenLayer, useGnbHooks } from "@/hooks/useGnbHook";
 import LanguageSwitcher from "./LanguageSwitcher";
+import { useTranslations } from "next-intl";
 
 // Gnb에서 정의해야 하는 요소들
 // 화면 너비에 따라 UI가 바뀜
@@ -23,6 +24,7 @@ interface GnbProps {
 export default function Gnb() {
   const { user, isLoading, logout } = useAuth();
   const { handleResize, isLg, openLayer, setOpenLayer } = useGnbHooks();
+  const t = useTranslations("Gnb");
 
   // user가 null이면 비로그인 상태
 
@@ -112,7 +114,7 @@ export default function Gnb() {
                 <div>
                   <Button
                     type="orange"
-                    text="로그인"
+                    text={t("login")}
                     className="h-12 w-30 rounded-lg"
                     onClick={() => router.push("/login/customer")}
                   />


### PR DESCRIPTION
## 📝작업 내용
- 대기 중인 견적/ 받았던 견적
- 작성 가능한 리뷰 / 내 리뷰

데스크탑 해상도에서 최대한 자연스럽게 좌측정렬 되도록 조정했습니다.

에러 없길...!

<img width="1686" height="299" alt="대기 중인 견적" src="https://github.com/user-attachments/assets/0be411ad-5ff2-4435-b9b2-84064fa60b97" />

<img width="1287" height="292" alt="대기 중인 견적" src="https://github.com/user-attachments/assets/2f926a8e-1a4e-4c24-b3fa-32db8fc3ecb3" />

<img width="1557" height="255" alt="리뷰" src="https://github.com/user-attachments/assets/eb7ed034-3562-4cfd-b04f-6e0486eed915" />
