### PR TITLE
refactor: 주소 정적 번역 비동기로 수정

### DIFF
--- a/src/messages/en/EstimateReq.json
+++ b/src/messages/en/EstimateReq.json
@@ -49,5 +49,6 @@
   },
   "sameAddressNotAllowed": "Departure and destination must be different.",
   "moveDateInPast": "You cannot request a move for a past date.",
-  "activeEstimateExists": "You already have an active moving request."
+  "activeEstimateExists": "You already have an active moving request.",
+  "translating": "Fetching the address..."
 }

--- a/src/messages/ko/EstimateReq.json
+++ b/src/messages/ko/EstimateReq.json
@@ -49,5 +49,6 @@
   },
   "sameAddressNotAllowed": "출발지와 도착지는 서로 달라야 합니다.",
   "moveDateInPast": "이전 날짜로 이사를 요청할 수 없습니다.",
-  "activeEstimateExists": "진행 중인 이사 견적이 있습니다."
+  "activeEstimateExists": "진행 중인 이사 견적이 있습니다.",
+  "translating": "주소를 번역 중입니다."
 }

--- a/src/messages/zh/EstimateReq.json
+++ b/src/messages/zh/EstimateReq.json
@@ -49,5 +49,6 @@
   },
   "sameAddressNotAllowed": "出发地和目的地不能相同。",
   "moveDateInPast": "不能请求过去日期的搬家。",
-  "activeEstimateExists": "您已经有正在进行的搬家请求。"
+  "activeEstimateExists": "您已经有正在进行的搬家请求。",
+  "translating": "正在获取地址..."
 }


### PR DESCRIPTION
## 📝작업 내용
- 다국어 주소를 불러올 때 카드 모달에서 로딩이 길어지는 문제가 발생해 카드를 미리 불러오고 번역을 비동기로 처리하도록 수정했습니다.

### 스크린샷 (선택)
<img width="619" height="521" alt="스크린샷 2025-08-06 오후 2 35 16(2)" src="https://github.com/user-attachments/assets/8ff496e1-ff3b-4b42-93aa-c84409612f58" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
