### PR TITLE
style: 탭 헤더 높이 및 기사찾기 카드 마진 레이아웃 수정

### DIFF
--- a/src/app/[locale]/(guest)/drivers/_components/FindDrivers.tsx
+++ b/src/app/[locale]/(guest)/drivers/_components/FindDrivers.tsx
@@ -69,7 +69,7 @@ function FindDrivers() {
 
   return (
     <main className="mb-20 flex justify-center px-6 pt-[6px]" aria-label={t("findDriver")}>
-      <section className="mx-6 w-full max-w-205" aria-labelledby="findDriverTitle">
+      <section className="w-full max-w-205" aria-labelledby="findDriverTitle">
         <h1 id="findDriverTitle" className="my-8 hidden text-3xl font-semibold lg:block">
           {t("findDriver")}
         </h1>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -47,7 +47,7 @@ export default function Header({ type, selectedIdx, setSelectedIdx }: HeaderProp
     // base: [""],
     // sm: ["sm: sm:px-6 sm:w-full"],
     // md: ["md: md:px-18 md:w-full"]
-    base: ["lg:gap-8 lg:pt-4 "],
+    base: ["lg:gap-8 lg:pt-4 lg:h-20"],
     sm: ["sm:gap-6 "],
     md: ["md:gap-6 "]
   };
@@ -56,7 +56,7 @@ export default function Header({ type, selectedIdx, setSelectedIdx }: HeaderProp
     <div className="border-line-100 flex items-center justify-center border-b-1 bg-gray-50 pb-0 shadow-[0px_2px_10px_rgba(248,248,248,0.10)]">
       <div
         className={clsx(
-          "flex w-full max-w-[var(--container-gnb)] min-w-[375px] flex-row items-start px-6 lg:pl-55 xl:pl-49",
+          "flex h-[54px] w-full max-w-[var(--container-gnb)] min-w-[375px] flex-row items-start px-6 lg:pl-55 xl:pl-49",
           ...SIZE_CLASSES.base,
           ...SIZE_CLASSES.md,
           ...SIZE_CLASSES.sm


### PR DESCRIPTION
## 📝작업 내용
- 탭 헤더 높이 수정했습니다.
- 기사님 찾기에서 무한스크롤시 카드 양옆 마진이 사라지는 문제가 있어서, 카드 마진 없애고 상위 레이아웃에서 패딩 추가해 처리했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
