### PR TITLE
style: 랜딩페이지 모바일 대응

### DIFF
--- a/src/app/[locale]/landing/_component/ChangeImages.tsx
+++ b/src/app/[locale]/landing/_component/ChangeImages.tsx
@@ -21,7 +21,7 @@ export default function ChangeImages() {
   let estimateVisualImg = ImgEstimateVisualDefault;
   if (windowWidth >= 1280) {
     estimateVisualImg = ImgEstimateVisualLg;
-  } else if (windowWidth >= 375) {
+  } else if (windowWidth >= 744) {
     estimateVisualImg = ImgEstimateVisualMd;
   }
 

--- a/src/app/[locale]/landing/_component/MovingCard.tsx
+++ b/src/app/[locale]/landing/_component/MovingCard.tsx
@@ -25,11 +25,11 @@ export default function MovingCard({ type }: { type: "small" | "family" | "offic
     }
   };
   return (
-    <div className="bg-background-200 flex min-h-31 min-w-31 flex-col items-center justify-center rounded-[20px] border-orange-300 transition-all delay-100 duration-300 ease-in-out hover:scale-120 hover:border-2 sm:min-h-50 sm:min-w-50 sm:hover:border-3">
-      <Image src={MOVING_TYPE[type].src} alt="소형이사" width={52} height={52} className="h-14 w-14 sm:h-25 sm:w-25" />
+    <div className="bg-background-200 flex min-h-31 min-w-31 flex-col items-center justify-center rounded-[20px] border-orange-300 transition-all delay-100 duration-300 ease-in-out hover:scale-120 hover:border-2 md:min-h-50 md:min-w-50 md:hover:border-3">
+      <Image src={MOVING_TYPE[type].src} alt="소형이사" width={52} height={52} className="h-14 w-14 md:h-25 md:w-25" />
       <div className="mt-2 flex flex-col text-center sm:mt-4">
-        <span className="text-black-500 text-[10px] font-bold sm:text-base">{MOVING_TYPE[type].titleText}</span>
-        <span className="text-[8px] font-medium text-gray-500 sm:text-[10px]">{MOVING_TYPE[type].subText}</span>
+        <span className="text-black-500 text-[10px] font-bold md:text-base">{MOVING_TYPE[type].titleText}</span>
+        <span className="text-[8px] font-medium text-gray-500 md:text-[10px]">{MOVING_TYPE[type].subText}</span>
       </div>
     </div>
   );

--- a/src/app/[locale]/landing/page.tsx
+++ b/src/app/[locale]/landing/page.tsx
@@ -22,8 +22,8 @@ const estimateCardStyle = {
   default: "w-83 h-67 lg:w-108 lg:h-86 transition-all",
   "1stImg": "absolute duration-300 -top-42 left-8 lg:-top-100 lg:left-130",
   "2ndImg": "absolute duration-800 top-30 left-8 lg:-top-10 lg:left-130",
-  "3rdImg": "hidden absolute sm:inline -top-25 left-95 lg:-top-80 lg:left-240 duration-500",
-  "4thImg": "hidden absolute sm:inline top-47 left-95 lg:top-10 lg:left-240 duration-1000"
+  "3rdImg": "hidden absolute md:inline -top-25 left-95 lg:-top-80 lg:left-240 duration-500",
+  "4thImg": "hidden absolute md:inline top-47 left-95 lg:top-10 lg:left-240 duration-1000"
 };
 
 const estimateCard = [
@@ -73,10 +73,10 @@ export default function LandingPage() {
         ></div>
         {/* 텍스트 영역: 항상 z-10로 이미지 위에 */}
         <div className="absolute inset-0 top-30 z-2 flex flex-col items-center justify-center 2xl:top-52">
-          <div className={`${translateStyle} text-center text-xl font-bold text-gray-50 duration-800 sm:text-[32px]`}>
+          <div className={`${translateStyle} text-center text-xl font-bold text-gray-50 duration-800 md:text-[32px]`}>
             {t("title")}
           </div>
-          <div className={`${translateStyle} mt-3 text-center text-base text-gray-100 duration-1000 sm:text-lg/snug`}>
+          <div className={`${translateStyle} mt-3 text-center text-base text-gray-100 duration-1000 md:text-lg/snug`}>
             {t("detail")}
             <br /> {t("brDetail")}
           </div>
@@ -86,7 +86,7 @@ export default function LandingPage() {
         padding="px-0 md:px-8"
         className="mt-13 mb-20 flex flex-col md:mt-15 lg:mt-29 lg:mb-32 lg:max-w-[1400px] lg:flex-row lg:items-center lg:justify-between"
       >
-        <div className="text-black-400 ml-8 text-xl font-bold sm:text-[32px] md:ml-0">
+        <div className="text-black-400 ml-8 text-xl font-bold md:ml-0 md:text-[32px]">
           {t("typeTitle")}
           <br />
           {t("brTypeTitle")}
@@ -103,7 +103,7 @@ export default function LandingPage() {
         <ChangeImages />
       </Container>
       <Container padding="px-0 sm:px-8" className="flex justify-center md:max-w-[1400px]">
-        <div className="text-black-400 ml-8 w-full bg-bottom-right bg-no-repeat pt-10 pb-46 text-xl font-bold sm:ml-0 sm:bg-[url(/assets/images/img_landing_building.svg)] sm:pt-44 sm:text-[32px] lg:bg-bottom-left">
+        <div className="text-black-400 ml-8 w-full bg-bottom-right bg-no-repeat pt-10 pb-46 text-xl font-bold md:ml-0 md:bg-[url(/assets/images/img_landing_building.svg)] md:pt-44 md:text-[32px] lg:bg-bottom-left">
           {t("compareTitle")}
           <br />
           {t("brCompareTitle")}
@@ -125,7 +125,7 @@ export default function LandingPage() {
       <Container
         maxWidth="w-full"
         padding="0"
-        className="flex flex-col items-center gap-3 bg-orange-400 py-10 sm:gap-4 sm:py-20"
+        className="flex flex-col items-center gap-3 bg-orange-400 py-10 md:gap-4 md:py-20"
       >
         <Image
           src={IconApp}


### PR DESCRIPTION
## 📝작업 내용
(브랜치를 못 바꿨네요 ㅠㅠ)
- 랜딩 페이지가 화면크기 374일때부터 모바일 화면으로 적용이 되어있어 크기 수정했습니다.
- 모바일 환경일 때는 브레이크 포인트(`sm`) 없이 적어주셔야 제대로 적용됩니다!

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
