### PR TITLE
fix: 리뷰 불러오는 중일 때 스켈레톤

### DIFF
--- a/src/components/driver/DriverReviews.tsx
+++ b/src/components/driver/DriverReviews.tsx
@@ -29,7 +29,7 @@ function DriverReviews({ driver }: ReviewsType) {
     placeholderData: keepPreviousData
   });
 
-  if (!reviews)
+  if (!reviews && !isPending && !isFetching)
     return (
       <section role="alert" aria-live="assertive" className="mb-50">
         <p>{t("reviewFetchFailed")}</p>
@@ -52,7 +52,7 @@ function DriverReviews({ driver }: ReviewsType) {
             <DriverReviewSkeleton key={i} />
           ))}
         </div>
-      ) : reviews.length ? (
+      ) : reviews && reviews.length ? (
         <>
           <section className="mt-4 flex flex-col justify-between gap-6 md:flex-row" aria-label={t("reviewSummary")}>
             <div className="flex gap-[18px]" aria-live="polite">


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. 리뷰 불러오는 중일 때 리뷰를 불러올 수 없다는 내용이 뜨는데 삭제하고 스켈레톤 뜨도록 했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
