### PR TITLE
[Fix/profileui 이지수]  ui 변경 및 기사 닉네임 중복 메세지 추가

### DIFF
--- a/src/app/[locale]/(auth)/login/customer/page.tsx
+++ b/src/app/[locale]/(auth)/login/customer/page.tsx
@@ -25,7 +25,7 @@ export default function LoginCustomer() {
   }, []);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[110px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[0px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
       <div className="relative mt-[36px] flex w-full max-w-[327px] flex-col gap-[40px] md:mt-[40px] md:w-[640px] md:max-w-none md:gap-[48px] md:rounded-[40px] md:bg-gray-50 md:px-[40px] md:py-[68px] lg:mt-[48px] lg:w-[740px] lg:px-[50px] lg:py-[48px]">
         <div className="flex flex-col md:gap-[8px]">
           <div className="flex h-[84px] w-full items-center justify-center md:h-[100px]">

--- a/src/app/[locale]/(auth)/login/driver/page.tsx
+++ b/src/app/[locale]/(auth)/login/driver/page.tsx
@@ -25,7 +25,7 @@ export default function LoginDriver() {
   }, []);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[110px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[0px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
       <div className="relative mt-[36px] flex w-full max-w-[327px] flex-col gap-[40px] md:mt-[40px] md:w-[640px] md:max-w-none md:gap-[48px] md:rounded-[40px] md:bg-gray-50 md:px-[40px] md:py-[68px] lg:mt-[48px] lg:w-[740px] lg:px-[50px] lg:py-[48px]">
         <div className="flex flex-col md:gap-[8px]">
           <div className="flex h-[84px] w-full items-center justify-center md:h-[100px]">

--- a/src/app/[locale]/(auth)/signup/customer/page.tsx
+++ b/src/app/[locale]/(auth)/signup/customer/page.tsx
@@ -29,7 +29,7 @@ export default function SignupCustomer() {
   } = useSignupForm(UserType.CUSTOMER);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[110px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[0px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
       <div className="relative mt-[36px] flex w-full max-w-[327px] flex-col gap-[40px] md:mt-[40px] md:w-[640px] md:max-w-none md:gap-[48px] md:rounded-[40px] md:bg-gray-50 md:px-[40px] md:py-[68px] lg:mt-[48px] lg:w-[740px] lg:px-[50px] lg:py-[48px]">
         <div className="flex flex-col md:gap-[8px]">
           <div className="flex h-[84px] w-full items-center justify-center md:h-[100px]">

--- a/src/app/[locale]/(auth)/signup/driver/page.tsx
+++ b/src/app/[locale]/(auth)/signup/driver/page.tsx
@@ -29,7 +29,7 @@ export default function SignupDriver() {
   } = useSignupForm(UserType.DRIVER);
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[110px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 pt-[0px] md:bg-orange-400 md:p-0 md:pb-15 lg:pb-15">
       <div className="relative mt-[36px] flex w-full max-w-[327px] flex-col gap-[40px] md:mt-[40px] md:w-[640px] md:max-w-none md:gap-[48px] md:rounded-[40px] md:bg-gray-50 md:px-[40px] md:py-[68px] lg:mt-[48px] lg:w-[740px] lg:px-[50px] lg:py-[48px]">
         <div className="flex flex-col md:gap-[8px]">
           <div className="flex h-[84px] w-full items-center justify-center md:h-[100px]">

--- a/src/components/profile/CustomerProfileCreateForm.tsx
+++ b/src/components/profile/CustomerProfileCreateForm.tsx
@@ -27,19 +27,14 @@ export default function CustomerProfileCreateForm() {
   const [imageError, setImageError] = useState<string | null>(null);
 
   // 성공적으로 제출 할 경우 꺼줄 가드
-   const [guardEnabled, setGuardEnabled] = useState(true);
+  const [guardEnabled, setGuardEnabled] = useState(true);
 
   const isFormValid = selectedMoveTypes.length > 0 && currentArea !== "";
 
-  // 이탈 방지 
-   const isDirty = useMemo(() => {
+  // 이탈 방지
+  const isDirty = useMemo(() => {
     if (isSubmitting || isUploading) return false;
-    return (
-      selectedMoveTypes.length > 0 ||
-      currentArea !== "" ||
-      !!profileImageFile ||
-      !!profileImagePreview
-    );
+    return selectedMoveTypes.length > 0 || currentArea !== "" || !!profileImageFile || !!profileImagePreview;
   }, [isSubmitting, isUploading, selectedMoveTypes.length, currentArea, profileImageFile, profileImagePreview]);
 
   useUnsavedChangesGuard({
@@ -47,7 +42,7 @@ export default function CustomerProfileCreateForm() {
     message: t1("leaveWarning"),
     interceptLinks: true,
     interceptBeforeUnload: true,
-    patchRouterMethods: true,
+    patchRouterMethods: true
   });
 
   const handleImageError = (error: string | null) => {

--- a/src/components/profile/CustomerProfileEditForm.tsx
+++ b/src/components/profile/CustomerProfileEditForm.tsx
@@ -87,24 +87,19 @@ export default function CustomerProfileEditForm({ initialData }: CustomerProfile
     throw new Error(t("error.upload.fail"));
   };
 
-  // 이탈 방지 
-     const isDirty = useMemo(() => {
-      if (isSubmitting || isUploading) return false;
-      return (
-        selectedMoveTypes.length > 0 ||
-        currentArea !== "" ||
-        !!profileImageFile ||
-        !!profileImagePreview
-      );
-    }, [isSubmitting, isUploading, selectedMoveTypes.length, currentArea, profileImageFile, profileImagePreview]);
-  
-    useUnsavedChangesGuard({
-      when: guardEnabled && isDirty,
-      message: t1("leaveWarning"),
-      interceptLinks: true,
-      interceptBeforeUnload: true,
-      patchRouterMethods: true,
-    });
+  // 이탈 방지
+  const isDirty = useMemo(() => {
+    if (isSubmitting || isUploading) return false;
+    return selectedMoveTypes.length > 0 || currentArea !== "" || !!profileImageFile || !!profileImagePreview;
+  }, [isSubmitting, isUploading, selectedMoveTypes.length, currentArea, profileImageFile, profileImagePreview]);
+
+  useUnsavedChangesGuard({
+    when: guardEnabled && isDirty,
+    message: t1("leaveWarning"),
+    interceptLinks: true,
+    interceptBeforeUnload: true,
+    patchRouterMethods: true
+  });
 
   const handleImageChange = async (file: File | null, previewUrl: string | null) => {
     setImageError(null);
@@ -197,7 +192,7 @@ export default function CustomerProfileEditForm({ initialData }: CustomerProfile
     <main role="main">
       <form
         onSubmit={handleSubmit}
-        className="mx-auto mt-[23px] box-border flex w-[372px] max-w-[1200px] flex-col gap-12 rounded-[32px] bg-gray-50 px-6 pt-8 pb-10 md:w-[372px] lg:w-[1200px] lg:px-10"
+        className="mx-auto mt-[23px] box-border flex w-[375px] max-w-[1200px] flex-col gap-12 rounded-[32px] bg-gray-50 px-6 pt-8 pb-10 md:w-[375px] lg:w-[1200px] lg:px-10"
       >
         {/* 상단 제목 */}
         <header className="flex flex-col gap-8">

--- a/src/components/profile/DriverProfileForm.tsx
+++ b/src/components/profile/DriverProfileForm.tsx
@@ -209,7 +209,11 @@ export default function DriverProfileForm({ isEditMode, initialData }: DriverPro
     } catch (error: any) {
       setGuardEnabled(true);
       console.error(error);
-      ToastModal(t(isEditMode ? "error.edit" : "error.create"));
+      if (error?.message === "이미 사용 중인 닉네임입니다.") {
+        ToastModal(error.message); // 백엔드 메시지 그대로
+      } else {
+        ToastModal(t(isEditMode ? "error.edit" : "error.create"));
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -298,9 +302,6 @@ export default function DriverProfileForm({ isEditMode, initialData }: DriverPro
                 onChange={setDetailIntro}
                 setInputValid={() => {}}
               />
-              {!isDescriptionValid && detailIntro.length > 0 && (
-                <p className="text-base text-rose-500">{t("descriptionError")}</p>
-              )}
             </div>
 
             <div className="bg-line-100 h-px" />


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 로그인, 회원가입 모바일 페이지 높이값 조절
2. 기사 생성 수정 시 중복 닉네임이면 에러 메세지 출력
3. 프로필 수정 페이지 모바일에서 인풋값 넓이 수정
4. 기사 생성 및 수정 페이지 유효성검사 에러메세지 중복 출력 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
